### PR TITLE
UCLII tables

### DIFF
--- a/src/main/java/org/xmlcml/html/HtmlElement.java
+++ b/src/main/java/org/xmlcml/html/HtmlElement.java
@@ -277,7 +277,7 @@ public abstract class HtmlElement extends Element implements XMLConstants {
 	 * @param element
 	 * @return
 	 */
-	@Deprecated // use HtmlFactory
+	
 	public static HtmlElement create(Element element) {
 		return HtmlElement.create(element, false, false);
 	}
@@ -292,7 +292,7 @@ public abstract class HtmlElement extends Element implements XMLConstants {
 	 * @param ignores namespaces (e.g. from Jsoup)
 	 * @return
 	 */
-	@Deprecated // use HtmlFactory instead
+	
 	private static HtmlElement create(Element element, boolean abort, boolean ignoreNamespaces) {
 		HtmlElement htmlElement = null;
 		String tag = element.getLocalName();

--- a/src/main/java/org/xmlcml/html/HtmlTable.java
+++ b/src/main/java/org/xmlcml/html/HtmlTable.java
@@ -84,8 +84,8 @@ public class HtmlTable extends HtmlElement {
 		return (HtmlTfoot) getSingleChildElement(this, HtmlTfoot.TAG); 
 	}
 
-	public HtmlTbody getThead() {
-		return (HtmlTbody) getSingleChildElement(this, HtmlThead.TAG); 
+	public HtmlThead getThead() {
+		return (HtmlThead) getSingleChildElement(this, HtmlThead.TAG); 
 	}
 
 	public HtmlTr getSingleLeadingTrThChild() {

--- a/src/main/java/org/xmlcml/html/HtmlTbody.java
+++ b/src/main/java/org/xmlcml/html/HtmlTbody.java
@@ -16,7 +16,9 @@
 
 package org.xmlcml.html;
 
+import java.util.ArrayList;
 import java.util.List;
+import nu.xom.Elements;
 
 import org.apache.log4j.Logger;
 
@@ -37,8 +39,31 @@ public class HtmlTbody extends HtmlElement {
 	public HtmlTbody() {
 		super(TAG);
 	}
+               
+        public void addRow(HtmlTr row) {
+		this.appendChild(row);
+	}
 	
 	public List<HtmlElement> getRows() {
 		return getChildElements(this, HtmlTr.TAG);
 	}
+        
+        public List<HtmlTr> getChildTrs() {
+            List<HtmlTr> rowList = new ArrayList<HtmlTr>();
+            List<HtmlElement> rows = getChildElements(this, HtmlTr.TAG);
+            for (HtmlElement el : rows) {
+                rowList.add((HtmlTr) el);
+            }
+            return rowList;
+        }
+        
+        public List<HtmlElement> getChildElementsList() {
+            Elements elts = this.getChildElements();
+            
+            List<HtmlElement> elements = new ArrayList<HtmlElement>();
+            for (int i = 0; i < elts.size(); i++) {
+                elements.add((HtmlElement) elts.get(i));
+            }
+            return elements;
+    }
 }

--- a/src/main/java/org/xmlcml/html/HtmlThead.java
+++ b/src/main/java/org/xmlcml/html/HtmlThead.java
@@ -41,4 +41,8 @@ public class HtmlThead extends HtmlElement {
 	public HtmlThead() {
 		super(TAG);
 	}
+        
+        public void addRow(HtmlTr row) {
+		this.appendChild(row);
+	}
 }

--- a/src/main/java/org/xmlcml/html/HtmlThead.java
+++ b/src/main/java/org/xmlcml/html/HtmlThead.java
@@ -16,6 +16,8 @@
 
 package org.xmlcml.html;
 
+import java.util.ArrayList;
+import java.util.List;
 import org.apache.log4j.Logger;
 
 
@@ -45,4 +47,13 @@ public class HtmlThead extends HtmlElement {
         public void addRow(HtmlTr row) {
 		this.appendChild(row);
 	}
+        
+        public List<HtmlTr> getChildTrs() {
+            List<HtmlTr> rowList = new ArrayList<HtmlTr>();
+            List<HtmlElement> rows = getChildElements(this, HtmlTr.TAG);
+            for (HtmlElement el : rows) {
+                rowList.add((HtmlTr) el);
+            }
+            return rowList;
+        }
 }


### PR DESCRIPTION
Extended existing classes needed to support output of HTML5 tables in semantically structured format (e.g., ```tbody``` used to represent a subtable).